### PR TITLE
fix(bigint): correct log2(10) buffer-estimate constant

### DIFF
--- a/patches/bflat-runtime/17_bigint.patch
+++ b/patches/bflat-runtime/17_bigint.patch
@@ -2,51 +2,36 @@ diff --git a/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.
 index 2ec19b8d824..af3c72aa4cd 100644
 --- a/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
 +++ b/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
-@@ -369,8 +369,14 @@ private static ParsingStatus NumberToBigInteger(ref NumberBuffer number, out Big
+@@ -369,8 +369,12 @@ private static ParsingStatus NumberToBigInteger(ref NumberBuffer number, out Big
                  Debug.Assert(intDigits.Length == 0);
              }
  
 -            const double digitRatio = 0.10381025297; // log_{2^32}(10)
 -            int resultLength = checked((int)(digitRatio * number.Scale) + 1 + 2);
-+            // Estimate required uint length using integer math only.
-+            // We need ceil(number.Scale * log2(10) / 32) + a small safety margin.
-+            // log2(10) ~= 3.321928094887362. We approximate ceil(x * log2(10) / 32) as:
-+            // ceil(x * 3566893132 / (1<<30) / 32) == ceil(x * 3566893132 / (1<<35)).
-+            const long Log2_10_Q30 = 3566893132L; // round(log2(10) * 2^30)
-+            long scale = number.Scale;
-+            long estimatedWords = checked((scale * Log2_10_Q30 + ((1L << 35) - 1)) >> 35);
-+            int resultLength = checked((int)estimatedWords + 3); // +3 provides slack for carry/rounding
++            // Upper bound on the uint words needed for a `digitCount`-digit base-10 number:
++            // ceil(digitCount * log2(10) / 32), using round(log2(10) * 2^30) == 3566893132 and >> 35.
++            static int EstimateWordCount(long digitCount) =>
++                checked((int)((digitCount * 3566893132L + ((1L << 35) - 1)) >> 35));
++
++            int resultLength = EstimateWordCount(number.Scale) + 1 + 2;
              uint[]? resultBufferFromPool = null;
              Span<uint> resultBuffer = (
                  resultLength <= BigIntegerCalculator.StackAllocThreshold
-@@ -415,7 +421,14 @@ static void DivideAndConquer(ReadOnlySpan<uint> base1E9, int trailingZeroCount,
+@@ -415,7 +419,7 @@ static void DivideAndConquer(ReadOnlySpan<uint> base1E9, int trailingZeroCount,
  
                  if (trailingZeroCount > 0)
                  {
 -                    int leadingLength = checked((int)(digitRatio * PowersOf1e9.MaxPartialDigits * base1E9.Length) + 3);
-+                    // Estimate required uint length using integer math only.
-+                    // digitCount ~= MaxPartialDigits * base1E9.Length
-+                    // words ~= ceil(digitCount * log2(10) / 32) with a small safety margin.
-+                    const long Log2_10_Q30 = 3566893132L; // round(log2(10) * 2^30)
-+                    long digitCount = checked((long)PowersOf1e9.MaxPartialDigits * base1E9.Length);
-+                    long estimatedWords = checked((digitCount * Log2_10_Q30 + ((1L << 35) - 1)) >> 35);
-+                    int leadingLength = checked((int)estimatedWords + 3);
-+
++                    int leadingLength = checked(EstimateWordCount((long)PowersOf1e9.MaxPartialDigits * base1E9.Length) + 3);
                      uint[]? leadingFromPool = null;
                      Span<uint> leading = (
                          leadingLength <= BigIntegerCalculator.StackAllocThreshold
-@@ -462,7 +475,13 @@ static void Recursive(in PowersOf1e9 powersOf1e9, int powersOf1e9Index, ReadOnly
+@@ -462,7 +466,7 @@ static void Recursive(in PowersOf1e9 powersOf1e9, int powersOf1e9Index, ReadOnly
  
                  Debug.Assert(multiplier1E9Length < base1E9.Length && base1E9.Length <= multiplier1E9Length * 2);
  
 -                int bufferLength = checked((int)(digitRatio * PowersOf1e9.MaxPartialDigits * multiplier1E9Length) + 1 + 2);
-+                // Estimate required uint length using integer math only.
-+                // digitCount ~= MaxPartialDigits * multiplier1E9Length
-+                // words ~= ceil(digitCount * log2(10) / 32) with a small safety margin.
-+                const long Log2_10_Q30 = 3566893132L; // round(log2(10) * 2^30)
-+                long digitCount = checked((long)PowersOf1e9.MaxPartialDigits * multiplier1E9Length);
-+                long estimatedWords = checked((digitCount * Log2_10_Q30 + ((1L << 35) - 1)) >> 35);
-+                int bufferLength = checked((int)estimatedWords + 3);
++                int bufferLength = checked(EstimateWordCount((long)PowersOf1e9.MaxPartialDigits * multiplier1E9Length) + 1 + 2);
                  uint[]? bufferFromPool = null;
                  scoped Span<uint> buffer = (
                      bufferLength <= BigIntegerCalculator.StackAllocThreshold

--- a/patches/bflat-runtime/17_bigint.patch
+++ b/patches/bflat-runtime/17_bigint.patch
@@ -11,8 +11,8 @@ index 2ec19b8d824..af3c72aa4cd 100644
 +            // Estimate required uint length using integer math only.
 +            // We need ceil(number.Scale * log2(10) / 32) + a small safety margin.
 +            // log2(10) ~= 3.321928094887362. We approximate ceil(x * log2(10) / 32) as:
-+            // ceil(x * 3321928095 / (1<<30) / 32) == ceil(x * 3321928095 / (1<<35)).
-+            const long Log2_10_Q30 = 3321928095L; // round(log2(10) * 2^30)
++            // ceil(x * 3566893132 / (1<<30) / 32) == ceil(x * 3566893132 / (1<<35)).
++            const long Log2_10_Q30 = 3566893132L; // round(log2(10) * 2^30)
 +            long scale = number.Scale;
 +            long estimatedWords = checked((scale * Log2_10_Q30 + ((1L << 35) - 1)) >> 35);
 +            int resultLength = checked((int)estimatedWords + 3); // +3 provides slack for carry/rounding
@@ -27,7 +27,7 @@ index 2ec19b8d824..af3c72aa4cd 100644
 +                    // Estimate required uint length using integer math only.
 +                    // digitCount ~= MaxPartialDigits * base1E9.Length
 +                    // words ~= ceil(digitCount * log2(10) / 32) with a small safety margin.
-+                    const long Log2_10_Q30 = 3321928095L; // round(log2(10) * 2^30)
++                    const long Log2_10_Q30 = 3566893132L; // round(log2(10) * 2^30)
 +                    long digitCount = checked((long)PowersOf1e9.MaxPartialDigits * base1E9.Length);
 +                    long estimatedWords = checked((digitCount * Log2_10_Q30 + ((1L << 35) - 1)) >> 35);
 +                    int leadingLength = checked((int)estimatedWords + 3);
@@ -43,7 +43,7 @@ index 2ec19b8d824..af3c72aa4cd 100644
 +                // Estimate required uint length using integer math only.
 +                // digitCount ~= MaxPartialDigits * multiplier1E9Length
 +                // words ~= ceil(digitCount * log2(10) / 32) with a small safety margin.
-+                const long Log2_10_Q30 = 3321928095L; // round(log2(10) * 2^30)
++                const long Log2_10_Q30 = 3566893132L; // round(log2(10) * 2^30)
 +                long digitCount = checked((long)PowersOf1e9.MaxPartialDigits * multiplier1E9Length);
 +                long estimatedWords = checked((digitCount * Log2_10_Q30 + ((1L << 35) - 1)) >> 35);
 +                int bufferLength = checked((int)estimatedWords + 3);


### PR DESCRIPTION
## Summary

Two related commits:

1. **Correctness fix.** The integer-math buffer-length estimate added to `17_bigint.patch` (BigInteger decimal parsing) used the constant `3321928095` with a binary `>> 35` shift. That constant is `round(log2(10) × 10⁹)` — a **decimal** scaling of log₂(10) — but it is divided by `2³⁵` (a **binary** unit). The unit mismatch makes the effective per-digit word multiplier `0.09668083` instead of the intended `log2(10)/32 = 0.10381025` — a **6.87% under-estimate** (matching the `round(log2(10)·2³⁰) = 3566893132` the comment claims). Fixed by using `3566893132`.

2. **Helper extraction.** The same estimate was duplicated across three sites (`NumberToBigInteger`, `DivideAndConquer`, `Recursive`), each with its own copy of the fixed-point constant. Extracted into a single `EstimateWordCount` static local function so the constant lives in exactly one place and can never drift between sites again. The overflow-`checked` additions on the two inner sites are preserved.

## Impact of the bug

The buffer carries a `+3` slack. The deficit `≈ 0.00713 · digitCount − 3` overtakes that slack once the digit count passes **~424**, after which the result buffer is undersized:

```
digitCount=424:   needed=45    estimate=44    (short by 1)
digitCount=1000:  needed=104   estimate=100   (short by 4)
digitCount=5000:  needed=520   estimate=487   (short by 33)
digitCount=100000:needed=10382 estimate=9672  (short by 710)
```

All three sites share the defect. An undersized buffer leads to out-of-bounds writes during conversion — reachable by parsing a `BigInteger` from any numeric string of a few hundred or more digits.

## Verification

Confirmed the corrected constant never under-allocates for digit counts from 1 to 2,000,000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
